### PR TITLE
feat: upgrade test parsing to yaml.v3 with strict validation and line numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/palantir/policy-bot v1.38.2
 	github.com/spf13/cobra v1.9.1
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/internal/loader/tests.go
+++ b/internal/loader/tests.go
@@ -1,11 +1,12 @@
 package loader
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
 	"github.com/reegnz/policy-bot-tests/internal/models"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // LoadTestFile loads and parses a test configuration file
@@ -14,9 +15,43 @@ func LoadTestFile(fileName string) (*models.TestFile, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to load file %s: %w", fileName, err)
 	}
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(testFile, &node); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
 	var tests models.TestFile
-	if err := yaml.UnmarshalStrict(testFile, &tests); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(testFile))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&tests); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal .policy-tests.yml: %w", err)
 	}
+
+	// Extract line numbers for test cases
+	extractLineNumbers(&node, &tests)
+
 	return &tests, nil
+}
+
+// extractLineNumbers extracts line numbers from YAML nodes and sets them on test cases
+func extractLineNumbers(node *yaml.Node, tests *models.TestFile) {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i]
+			value := node.Content[i+1]
+
+			if key.Value == "testCases" && value.Kind == yaml.SequenceNode {
+				for j, testNode := range value.Content {
+					if j < len(tests.TestCases) {
+						tests.TestCases[j].LineNumber = testNode.Line
+					}
+				}
+			}
+		}
+	}
 }

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -10,9 +10,10 @@ type TestFile struct {
 
 // TestCase represents a single test case from the YAML file
 type TestCase struct {
-	Name    string        `yaml:"name"`
-	Context TestContext   `yaml:"context"`
-	Assert  TestAssertion `yaml:"assert"`
+	Name       string        `yaml:"name"`
+	Context    TestContext   `yaml:"context"`
+	Assert     TestAssertion `yaml:"assert"`
+	LineNumber int           `yaml:"-"`
 }
 
 // TestContext is a simplified version of GitHubContext for easy YAML parsing

--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -42,7 +42,11 @@ func RunTests(evaluator common.Evaluator, tests *models.TestFile, verbosity int,
 	log.Printf("Running %d of %d total test case(s)\n", len(filteredCases), len(tests.TestCases))
 	passedCount := 0
 	for _, tc := range filteredCases {
-		log.Printf("--- Running Test: %s ---\n", tc.Name)
+		if tc.LineNumber > 0 {
+			log.Printf("--- Running Test: .policy-tests.yml:%d: %s ---\n", tc.LineNumber, tc.Name)
+		} else {
+			log.Printf("--- Running Test: %s ---\n", tc.Name)
+		}
 
 		mergedContext := MergeContexts(tests.DefaultContext, tc.Context)
 		pullContext := NewPullContext(mergedContext)


### PR DESCRIPTION
- Upgrade internal/loader/tests.go to use gopkg.in/yaml.v3
- Add strict unmarshalling with KnownFields(true) for better validation
- Implement line number extraction for test cases in .policy-tests.yml
- Update go.mod to include yaml.v3 dependency
- Refactor test models to support LineNumber field in TestCase
- Update test runner to display line numbers in test output format
- Keep policy parsing on yaml.v2 for compatibility with policy-bot library

Benefits:
- Catches YAML configuration errors early with strict field validation
- Shows exact line numbers when tests fail for easier debugging
- Maintains full compatibility with existing policy-bot functionality
