### PR TITLE
refactor(tests): rename test case fields to snake_case

### DIFF
--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -4,8 +4,8 @@ import "slices"
 
 // TestFile matches the root of the .policy-tests.yml file
 type TestFile struct {
-	DefaultContext TestContext `yaml:"defaultContext"`
-	TestCases      []TestCase  `yaml:"testCases"`
+	DefaultContext TestContext `yaml:"default_context"`
+	TestCases      []TestCase  `yaml:"test_cases"`
 }
 
 // TestCase represents a single test case from the YAML file
@@ -18,23 +18,23 @@ type TestCase struct {
 
 // TestContext is a simplified version of GitHubContext for easy YAML parsing
 type TestContext struct {
-	FilesChanged []string            `yaml:"filesChanged"`
+	FilesChanged []string            `yaml:"files_changed"`
 	Owner        string              `yaml:"owner"`
 	Repo         string              `yaml:"repo"`
 	PR           TestPullRequest     `yaml:"pr"`
 	Reviews      []TestReview        `yaml:"reviews"`
 	Statuses     map[string]string   `yaml:"statuses"`
-	WorkflowRuns map[string][]string `yaml:"workflowRuns"`
+	WorkflowRuns map[string][]string `yaml:"workflow_runs"`
 	Labels       []string            `yaml:"labels"`
-	TeamMembers  map[string][]string `yaml:"teamMembers"`
-	OrgMembers   map[string][]string `yaml:"orgMembers"`
+	TeamMembers  map[string][]string `yaml:"team_members"`
+	OrgMembers   map[string][]string `yaml:"org_members"`
 }
 
 // TestPullRequest is a simplified version of a PR for YAML parsing
 type TestPullRequest struct {
 	Author      string `yaml:"author"`
-	BaseRefName string `yaml:"baseRefName"`
-	HeadRefName string `yaml:"headRefName"`
+	BaseRefName string `yaml:"base_ref_name"`
+	HeadRefName string `yaml:"head_ref_name"`
 }
 
 // TestReview is a simplified version of a review for YAML parsing
@@ -45,10 +45,10 @@ type TestReview struct {
 
 // TestAssertion defines the expected outcomes of a test case
 type TestAssertion struct {
-	EvaluationStatus string   `yaml:"evaluationStatus"`
-	MustBeApproved   []string `yaml:"mustBeApproved"`
-	MustBePending    []string `yaml:"mustBePending"`
-	MustBeSkipped    []string `yaml:"mustBeSkipped"`
+	EvaluationStatus string   `yaml:"evaluation_status"`
+	MustBeApproved   []string `yaml:"must_be_approved"`
+	MustBePending    []string `yaml:"must_be_pending"`
+	MustBeSkipped    []string `yaml:"must_be_skipped"`
 }
 
 // AssertionResult holds the results of test assertions

--- a/tests/.policy-tests.yml
+++ b/tests/.policy-tests.yml
@@ -1,11 +1,11 @@
 ---
-defaultContext:
+default_context:
   owner: test
   repo: test
   pr:
-    baseRefName: main
-    headRefName: feature/changes
-  teamMembers:
+    base_ref_name: main
+    head_ref_name: feature/changes
+  team_members:
     test/team-alpha:
     - alpha-alice
     - alpha-bob
@@ -14,10 +14,10 @@ defaultContext:
     - beta-alice
     - beta-bob
     - beta-charlie
-testCases:
+test_cases:
 - name: Pass policy when team alpha files change and team alpha approves
   context:
-    filesChanged:
+    files_changed:
     - team-alpha/file.txt
     pr:
       author: alpha-alice
@@ -25,13 +25,13 @@ testCases:
     - author: alpha-bob
       state: approved
   assert:
-    evaluationStatus: approved
-    mustBeApproved:
+    evaluation_status: approved
+    must_be_approved:
     - team-alpha-review
 
 - name: Fail policy when team alpha files change and only PR author approves
   context:
-    filesChanged:
+    files_changed:
     - team-alpha/file.txt
     pr:
       author: alpha-alice
@@ -39,13 +39,13 @@ testCases:
     - author: alpha-alice
       state: approved
   assert:
-    evaluationStatus: pending
-    mustBePending:
+    evaluation_status: pending
+    must_be_pending:
     - team-alpha-review
 
 - name: Pass policy when multiple team files are changing with multiple team approvals
   context:
-    filesChanged:
+    files_changed:
     - team-alpha/file.txt
     - team-beta/file.txt
     pr:
@@ -56,15 +56,15 @@ testCases:
     - author: beta-charlie
       state: approved
   assert:
-    evaluationStatus: approved
-    mustBeApproved:
+    evaluation_status: approved
+    must_be_approved:
     - team-alpha-review
     - team-beta-review
 
 
 - name: Fail policy when multiple team files are changing with review missing from beta team
   context:
-    filesChanged:
+    files_changed:
     - team-alpha/file.txt
     - team-beta/file.txt
     pr:
@@ -73,8 +73,8 @@ testCases:
     - author: alpha-bob
       state: approved
   assert:
-    evaluationStatus: pending
-    mustBeApproved:
+    evaluation_status: pending
+    must_be_approved:
     - team-alpha-review
-    mustBePending:
+    must_be_pending:
     - team-beta-review


### PR DESCRIPTION
This change aligns the test case syntax with the snake_case format used in .policy.yml files. This ensures consistency across the policy and testing framework.
