### PR TITLE
refactor(tests): make author a top-level field

### DIFF
--- a/internal/models/context.go
+++ b/internal/models/context.go
@@ -213,7 +213,7 @@ func NewGitHubContext(tc TestContext, reviews []*pull.Review, files []*pull.File
 		owner:                   tc.Owner,
 		repo:                    tc.Repo,
 		pr: PullRequest{
-			author:      tc.PR.Author,
+			author:      tc.Author,
 			baseRefName: tc.PR.BaseRefName,
 			headRefName: tc.PR.HeadRefName,
 		},

--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -19,6 +19,7 @@ type TestCase struct {
 // TestContext is a simplified version of GitHubContext for easy YAML parsing
 type TestContext struct {
 	FilesChanged []string            `yaml:"files_changed"`
+	Author       string              `yaml:"author"`
 	Owner        string              `yaml:"owner"`
 	Repo         string              `yaml:"repo"`
 	PR           TestPullRequest     `yaml:"pr"`
@@ -32,7 +33,6 @@ type TestContext struct {
 
 // TestPullRequest is a simplified version of a PR for YAML parsing
 type TestPullRequest struct {
-	Author      string `yaml:"author"`
 	BaseRefName string `yaml:"base_ref_name"`
 	HeadRefName string `yaml:"head_ref_name"`
 }

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -11,7 +11,7 @@ import (
 
 // PrintTestContext prints the test context information with proper formatting
 func PrintTestContext(tc models.TestContext, indent string) {
-	log.Printf("%s- Author: %s", indent, tc.PR.Author)
+	log.Printf("%s- Author: %s", indent, tc.Author)
 	if len(tc.FilesChanged) > 0 {
 		log.Printf("%s- Changed Files:", indent)
 		for _, file := range tc.FilesChanged {

--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -132,8 +132,8 @@ func MergeContexts(base, override models.TestContext) models.TestContext {
 	if override.Repo != "" {
 		merged.Repo = override.Repo
 	}
-	if override.PR.Author != "" {
-		merged.PR.Author = override.PR.Author
+	if override.Author != "" {
+		merged.Author = override.Author
 	}
 	if override.PR.BaseRefName != "" {
 		merged.PR.BaseRefName = override.PR.BaseRefName

--- a/tests/.policy-tests.yml
+++ b/tests/.policy-tests.yml
@@ -19,8 +19,7 @@ test_cases:
   context:
     files_changed:
     - team-alpha/file.txt
-    pr:
-      author: alpha-alice
+    author: alpha-alice
     reviews:
     - author: alpha-bob
       state: approved
@@ -33,8 +32,7 @@ test_cases:
   context:
     files_changed:
     - team-alpha/file.txt
-    pr:
-      author: alpha-alice
+    author: alpha-alice
     reviews:
     - author: alpha-alice
       state: approved
@@ -48,8 +46,7 @@ test_cases:
     files_changed:
     - team-alpha/file.txt
     - team-beta/file.txt
-    pr:
-      author: alpha-alice
+    author: alpha-alice
     reviews:
     - author: alpha-bob
       state: approved
@@ -67,8 +64,7 @@ test_cases:
     files_changed:
     - team-alpha/file.txt
     - team-beta/file.txt
-    pr:
-      author: alpha-alice
+    author: alpha-alice
     reviews:
     - author: alpha-bob
       state: approved


### PR DESCRIPTION
This change simplifies the test case syntax by moving the author field out of the nested pr object. This improves readability and makes the test cases easier to maintain.
