### PR TITLE
feat(tests): add support for files_added and files_deleted

### DIFF
--- a/internal/models/test.go
+++ b/internal/models/test.go
@@ -19,6 +19,8 @@ type TestCase struct {
 // TestContext is a simplified version of GitHubContext for easy YAML parsing
 type TestContext struct {
 	FilesChanged []string            `yaml:"files_changed"`
+	FilesAdded   []string            `yaml:"files_added"`
+	FilesDeleted []string            `yaml:"files_deleted"`
 	Author       string              `yaml:"author"`
 	Owner        string              `yaml:"owner"`
 	Repo         string              `yaml:"repo"`

--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -126,6 +126,12 @@ func MergeContexts(base, override models.TestContext) models.TestContext {
 	if len(override.FilesChanged) > 0 {
 		merged.FilesChanged = override.FilesChanged
 	}
+	if len(override.FilesAdded) > 0 {
+		merged.FilesAdded = override.FilesAdded
+	}
+	if len(override.FilesDeleted) > 0 {
+		merged.FilesDeleted = override.FilesDeleted
+	}
 	if override.Owner != "" {
 		merged.Owner = override.Owner
 	}
@@ -176,7 +182,13 @@ func NewPullContext(tc models.TestContext) pull.Context {
 
 	files := []*pull.File{}
 	for _, f := range tc.FilesChanged {
-		files = append(files, &pull.File{Filename: f})
+		files = append(files, &pull.File{Filename: f, Status: pull.FileModified})
+	}
+	for _, f := range tc.FilesAdded {
+		files = append(files, &pull.File{Filename: f, Status: pull.FileAdded})
+	}
+	for _, f := range tc.FilesDeleted {
+		files = append(files, &pull.File{Filename: f, Status: pull.FileDeleted})
 	}
 
 	collaborators := []*pull.Collaborator{}


### PR DESCRIPTION
This change introduces support for the 'files_added' and 'files_deleted' predicates in the test runner. This allows for more granular testing of policy rules that depend on whether files are added or deleted in a pull request.
